### PR TITLE
Add dust particles on landing

### DIFF
--- a/junglejump/Player/player.gd
+++ b/junglejump/Player/player.gd
@@ -97,6 +97,7 @@ func _physics_process(delta):
 	if state == JUMP and is_on_floor():
 		change_state(IDLE)
 		jump_count = 0
+		$Dust.emitting = true
 		
 	if state == JUMP and velocity.y	> 0:
 		$AnimationPlayer.play("jump_down")

--- a/junglejump/Player/player.tscn
+++ b/junglejump/Player/player.tscn
@@ -119,6 +119,10 @@ _data = {
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_csshw"]
 size = Vector2(17.0025, 20)
 
+[sub_resource type="Gradient" id="Gradient_k53q1"]
+offsets = PackedFloat32Array(0, 0.9941349, 1)
+colors = PackedColorArray(1, 0.49019608, 0.32941177, 1, 1, 0.49019608, 0.32941177, 0, 1, 1, 1, 1)
+
 [node name="Player" type="CharacterBody2D" unique_id=1312860802]
 collision_layer = 2
 collision_mask = 13
@@ -152,3 +156,20 @@ stream = ExtResource("4_0kflm")
 
 [node name="JUMP_AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="." unique_id=1229665890]
 stream = ExtResource("5_xg08x")
+
+[node name="Dust" type="CPUParticles2D" parent="." unique_id=330662377]
+position = Vector2(-2, 0)
+rotation = -1.5707964
+emitting = false
+amount = 20
+lifetime = 0.45
+one_shot = true
+explosiveness = 0.7
+emission_shape = 3
+emission_rect_extents = Vector2(1, 6)
+gravity = Vector2(0, 0)
+initial_velocity_min = 10.0
+initial_velocity_max = 30.0
+scale_amount_min = 3.0
+scale_amount_max = 8.0
+color_ramp = SubResource("Gradient_k53q1")


### PR DESCRIPTION
Resolves #168

## Summary
- 플레이어에 `Dust` CPUParticles2D 노드 추가, 점프 후 착지 시 먼지 파티클 발생
- 가시성 조정: `speed_scale` 2.0 → 1.0 (실제 재생 시간 0.22초 → 0.45초), `scale_amount` min 3 / max 8, `initial_velocity` min 10 / max 30으로 착지 시 먼지가 옆으로 퍼지도록 설정

## Test
- 에디터에서 실행하여 점프 → 착지 시 발밑에서 먼지 파티클이 퍼지는 것 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)