### PR TITLE
Jungle Jump bug fixes

### DIFF
--- a/junglejump/Levels/level_base.gd
+++ b/junglejump/Levels/level_base.gd
@@ -6,6 +6,7 @@ var item_scene = load("res://Items/item.tscn")
 var door_scene = load("res://Items/door.tscn")
 
 var score = 0: set = set_score
+var fall_limit = 0.0
 
 func _ready():
 	$Items.hide()
@@ -13,7 +14,12 @@ func _ready():
 	set_camera_limits()
 	spawn_items()
 	create_ladders()
-	
+	fall_limit = $World.get_used_rect().end.y * $World.tile_set.tile_size.y
+
+func _process(_delta):
+	if $Player.life > 0 and $Player.position.y > fall_limit:
+		$Player.life = 0
+
 func set_camera_limits():
 	var map_size = $World.get_used_rect()
 	var cell_size = $World.tile_set.tile_size

--- a/junglejump/Levels/level_base.tscn
+++ b/junglejump/Levels/level_base.tscn
@@ -73,5 +73,6 @@ collision_mask = 2
 
 [connection signal="died" from="Player" to="." method="_on_player_died"]
 [connection signal="life_changed" from="Player" to="CanvasLayer/HUD" method="update_life"]
+[connection signal="score_changed" from="." to="CanvasLayer/HUD" method="update_score"]
 [connection signal="body_entered" from="Ladders" to="Player" method="_on_ladders_body_entered"]
 [connection signal="body_exited" from="Ladders" to="Player" method="_on_ladders_body_exited"]

--- a/junglejump/Main/game_state.gd
+++ b/junglejump/Main/game_state.gd
@@ -14,3 +14,5 @@ func next_level():
 	current_level += 1
 	if current_level <= num_levels:
 		get_tree().change_scene_to_file(game_scene)
+	else:
+		restart()

--- a/junglejump/Player/player.gd
+++ b/junglejump/Player/player.gd
@@ -37,7 +37,7 @@ func change_state(new_state):
 			life -= 1
 			if life > 0:
 				await get_tree().create_timer(0.5).timeout
-			change_state(IDLE)
+				change_state(IDLE)
 		JUMP:
 			$AnimationPlayer.play("jump_up")
 			$JUMP_AudioStreamPlayer2D.play()

--- a/junglejump/project.godot
+++ b/junglejump/project.godot
@@ -27,7 +27,6 @@ GameState="*res://Main/game_state.gd"
 
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
-window/main_scene="res://Player/player.tscn"
 
 [input]
 


### PR DESCRIPTION
Resolves #174

## Summary
- 점수 HUD 미표시 수정: `score_changed` → `HUD.update_score` 시그널 연결 추가 (level_base.tscn)
- 마지막 레벨 클리어 처리: `next_level()`에서 `current_level > num_levels`이면 `restart()`로 타이틀 복귀
- 사망 상태 유지: HURT 처리의 `change_state(IDLE)`을 `if life > 0:` 블록 안으로 이동해 DEAD 상태가 덮어써지지 않도록 수정
- `project.godot` `[display]` 섹션의 유효하지 않은 잔재 설정 `window/main_scene` 제거
- 무한 낙하 수정: 플레이어가 World 타일맵 바닥 아래로 떨어지면 기존 사망 흐름(life 0 → DEAD → died → 타이틀 복귀)으로 처리

## Test
- 체리/젬 획득 시 좌상단 점수 증가 확인 (자동 플레이 데모: #174 코멘트)
- 레벨 2 문 진입 시 타이틀 화면 복귀 확인
- 구덩이 낙하 시 사망 → 타이틀 복귀 확인 (헤드리스 자동 테스트 + 플레이 확인)
- 씬 로드/시그널 연결 헤드리스 스모크 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)