### PR TITLE
Improving ball collisions

### DIFF
--- a/3d-minigolf/ball.tscn
+++ b/3d-minigolf/ball.tscn
@@ -7,7 +7,14 @@ height = 0.1
 [sub_resource type="SphereShape3D" id="SphereShape3D_mih3r"]
 radius = 0.05
 
+[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_cki6r"]
+bounce = 0.25
+
 [node name="Ball" type="RigidBody3D" unique_id=1294271037]
+physics_material_override = SubResource("PhysicsMaterial_cki6r")
+continuous_cd = true
+linear_damp = 0.5
+angular_damp = 1.0
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="." unique_id=762107907]
 mesh = SubResource("SphereMesh_mih3r")

--- a/3d-minigolf/hole.tscn
+++ b/3d-minigolf/hole.tscn
@@ -55,4 +55,4 @@ shape = SubResource("CylinderShape3D_mih3r")
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.488662, 0.85620403, 5.9747605)
 
 [node name="Ball" parent="." unique_id=1294271037 instance=ExtResource("2_1s0jb")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.4856186, 1.3228927, 6)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.7434311, 1.3228927, 1.4480076)


### PR DESCRIPTION
Close #191

책 5.4장 'Improving ball collisions' 항목 작업.

- ball.tscn의 Ball 루트 노드에 물리 설정 적용 (인스턴스 오버라이드가 아닌 씬 자체 속성으로)
  - Continuous CD 활성화 — 빠른 공이 벽을 터널링하지 않도록
  - Linear Damp 0.5 / Angular Damp 1.0 — 구름 저항으로 공이 자연스럽게 멈춤
  - PhysicsMaterial bounce 0.25 — 과도한 반발 억제
- 물리 충돌/속도감 확인을 위해 공 테스트 위치를 커브 구간으로 이동 (#191 코멘트의 데모 GIF 참고)

🤖 Generated with [Claude Code](https://claude.com/claude-code)