### PR TITLE
Aiming the arrow

### DIFF
--- a/3d-minigolf/arrow.tscn
+++ b/3d-minigolf/arrow.tscn
@@ -1,0 +1,23 @@
+[gd_scene format=3 uid="uid://c8cbc2rtt0pis"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_o5gaf"]
+transparency = 1
+albedo_color = Color(0.38431373, 0.5568628, 1, 0.5019608)
+
+[sub_resource type="BoxMesh" id="BoxMesh_mih3r"]
+material = SubResource("StandardMaterial3D_o5gaf")
+size = Vector3(0.5, 0.2, 2)
+
+[sub_resource type="PrismMesh" id="PrismMesh_mih3r"]
+material = SubResource("StandardMaterial3D_o5gaf")
+size = Vector3(1.5, 1.5, 0.2)
+
+[node name="Arrow" type="Node3D" unique_id=990052558]
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="." unique_id=1624264836]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -1)
+mesh = SubResource("BoxMesh_mih3r")
+
+[node name="MeshInstance3D2" type="MeshInstance3D" parent="." unique_id=725627396]
+transform = Transform3D(1, 0, 0, 0, -4.371139e-08, 1, 0, -1, -4.371139e-08, 0, 0, -2.75)
+mesh = SubResource("PrismMesh_mih3r")

--- a/3d-minigolf/hole.tscn
+++ b/3d-minigolf/hole.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="MeshLibrary" uid="uid://boqpwqm1cph87" path="res://golf_tiles.meshlib" id="1_ln22a"]
 [ext_resource type="PackedScene" uid="uid://bhkrakk3ieqi6" path="res://ball.tscn" id="2_1s0jb"]
+[ext_resource type="PackedScene" uid="uid://c8cbc2rtt0pis" path="res://arrow.tscn" id="3_cki6r"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_j4rvs"]
 rough = true
@@ -56,3 +57,6 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.488662, 0.85620403, 5.9747
 
 [node name="Ball" parent="." unique_id=1294271037 instance=ExtResource("2_1s0jb")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.7434311, 1.3228927, 1.4480076)
+
+[node name="Arrow" parent="." unique_id=990052558 instance=ExtResource("3_cki6r")]
+transform = Transform3D(0.25, 0, 0, 0, 0.25, 0, 0, 0, 0.25, -0.4765377, 0.8705983, 5.9624)


### PR DESCRIPTION
Close #193

책 5.4장 'Adding UI - Aiming the arrow' 항목 작업.

- arrow.tscn 씬 추가: Node3D 루트 아래 BoxMesh(몸통) + PrismMesh(화살촉) 구성
  - 두 메시가 반투명 StandardMaterial3D를 공유
  - 화살표가 -Z(Godot forward) 방향을 가리키도록 배치 — 이후 스크립트에서 look_at()으로 조준 가능
- hole.tscn에 Arrow 인스턴스를 Tee 위치에 0.25 스케일로 배치
  - 스케일은 씬 루트가 아닌 인스턴스에서만 적용하도록 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)