### PR TITLE
UI display

### DIFF
--- a/3d-minigolf/hole.tscn
+++ b/3d-minigolf/hole.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="MeshLibrary" uid="uid://boqpwqm1cph87" path="res://golf_tiles.meshlib" id="1_ln22a"]
 [ext_resource type="PackedScene" uid="uid://bhkrakk3ieqi6" path="res://ball.tscn" id="2_1s0jb"]
 [ext_resource type="PackedScene" uid="uid://c8cbc2rtt0pis" path="res://arrow.tscn" id="3_cki6r"]
+[ext_resource type="PackedScene" uid="uid://6voinnuhm3gg" path="res://ui.tscn" id="4_aqv4r"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_j4rvs"]
 rough = true
@@ -60,3 +61,5 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.7434311, 1.3228927, 1.44800
 
 [node name="Arrow" parent="." unique_id=990052558 instance=ExtResource("3_cki6r")]
 transform = Transform3D(0.25, 0, 0, 0, 0.25, 0, 0, 0, 0.25, -0.4765377, 0.8705983, 5.9624)
+
+[node name="UI" parent="." unique_id=933499048 instance=ExtResource("4_aqv4r")]

--- a/3d-minigolf/ui.tscn
+++ b/3d-minigolf/ui.tscn
@@ -1,0 +1,53 @@
+[gd_scene format=3 uid="uid://6voinnuhm3gg"]
+
+[ext_resource type="FontFile" uid="uid://6b3ku588yurr" path="res://assets/Xolonium-Regular.ttf" id="1_m6e0p"]
+[ext_resource type="Texture2D" uid="uid://bhewwfrqbi6kl" path="res://assets/bar_green.png" id="2_27fn8"]
+
+[node name="UI" type="CanvasLayer" unique_id=933499048]
+
+[node name="Message" type="Label" parent="." unique_id=2030358589]
+visible = false
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -233.0
+offset_top = -48.5
+offset_right = 233.0
+offset_bottom = 48.5
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_fonts/font = ExtResource("1_m6e0p")
+theme_override_font_sizes/font_size = 80
+text = "Get Ready!"
+
+[node name="MarginContainer" type="MarginContainer" parent="." unique_id=371833814]
+offset_right = 40.0
+offset_bottom = 40.0
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer" unique_id=1845332046]
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="Shots" type="Label" parent="MarginContainer/VBoxContainer" unique_id=650998349]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("1_m6e0p")
+theme_override_font_sizes/font_size = 30
+text = "Shots: 0"
+
+[node name="PowerBar" type="TextureProgressBar" parent="MarginContainer/VBoxContainer" unique_id=783784920]
+layout_mode = 2
+value = 50.0
+fill_mode = 3
+texture_progress = ExtResource("2_27fn8")
+
+[node name="PowerLabel" type="Label" parent="MarginContainer/VBoxContainer" unique_id=1491671372]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("1_m6e0p")
+theme_override_font_sizes/font_size = 30
+text = "Power"


### PR DESCRIPTION
Close #195

책 5.4장 'Adding UI - UI display' 항목 작업.

- ui.tscn 씬 추가: CanvasLayer 루트 아래 UI 구성
  - Message 라벨 — 화면 중앙 앵커, 기본 숨김 (이후 스크립트에서 표시)
  - MarginContainer(여백 10px) > VBoxContainer에 Shots 라벨, PowerBar(TextureProgressBar, 아래→위 채움), Power 라벨 배치
  - Xolonium 폰트, bar_green 텍스처 사용
- hole.tscn에 UI 인스턴스 추가
  - CanvasLayer라 에디터 3D 뷰에는 안 보이고 실행 시 오버레이로 표시됨 (정상 동작)

🤖 Generated with [Claude Code](https://claude.com/claude-code)