### PR TITLE
Add main script for hole state machine (aim, power, shoot, win)

### DIFF
--- a/3d-minigolf/hole.gd
+++ b/3d-minigolf/hole.gd
@@ -1,0 +1,77 @@
+extends Node3D
+
+enum { AIM, SET_POWER, SHOOT, WIN }
+
+@export var power_speed = 100
+@export var angle_speed = 1.1
+
+var angle_change = 1
+var power = 0
+var power_change = 1
+var shots = 0
+var state = AIM
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	$Arrow.hide()
+	$Ball.position = $Tee.position
+	change_state(AIM)
+	$UI.show_message("Get Ready!")
+
+func change_state(new_state: int) -> void:
+	state = new_state
+	match state:
+		AIM:
+			$Arrow.position = $Ball.position
+			$Arrow.show()
+		SET_POWER:
+			power = 0
+		SHOOT:
+			$Arrow.hide()
+			# To do
+			# $Ball.shoot($Arrow.rotation.y, power / 15)
+			shots += 1
+			$UI.update_shots(shots)
+		WIN:
+			$Ball.hide()
+			$Arrow.hide()
+			$UI.show_message("Win!")
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("click"):
+		match state:
+			AIM:
+				change_state(SET_POWER)
+			SET_POWER:
+				change_state(SHOOT)
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	match state:
+		AIM:
+			animate_arrow(delta)
+		SET_POWER:
+			animate_power(delta)
+		SHOOT:
+			pass
+
+func animate_arrow(delta: float) -> void:
+	$Arrow.rotation.y += angle_speed * angle_change * delta
+	if $Arrow.rotation.y > PI / 2:
+		angle_change = -1
+	if $Arrow.rotation.y < -PI / 2:
+		angle_change = 1
+		
+func animate_power(delta: float) -> void:
+	power += power_speed * power_change * delta
+	if power >= 100:
+		power_change = -1
+	if power <= 0:
+		power_change = 1
+	$UI.update_power_bar(power)
+
+
+func _on_hole_body_entered(body: Node3D) -> void:
+	if body.name == "Ball":
+		print("win!")
+		change_state(WIN)

--- a/3d-minigolf/hole.gd.uid
+++ b/3d-minigolf/hole.gd.uid
@@ -1,0 +1,1 @@
+uid://dm4rxyidhwv3k

--- a/3d-minigolf/hole.tscn
+++ b/3d-minigolf/hole.tscn
@@ -1,5 +1,6 @@
 [gd_scene format=3 uid="uid://d00paw0untce8"]
 
+[ext_resource type="Script" uid="uid://dm4rxyidhwv3k" path="res://hole.gd" id="1_cr06n"]
 [ext_resource type="MeshLibrary" uid="uid://boqpwqm1cph87" path="res://golf_tiles.meshlib" id="1_ln22a"]
 [ext_resource type="PackedScene" uid="uid://bhkrakk3ieqi6" path="res://ball.tscn" id="2_1s0jb"]
 [ext_resource type="PackedScene" uid="uid://c8cbc2rtt0pis" path="res://arrow.tscn" id="3_cki6r"]
@@ -27,6 +28,7 @@ height = 0.25
 radius = 0.08
 
 [node name="Hole" type="Node3D" unique_id=10753398]
+script = ExtResource("1_cr06n")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="." unique_id=1395984302]
 transform = Transform3D(-0.8660254, -0.43301278, 0.25, 0, 0.49999997, 0.86602545, -0.50000006, 0.75, -0.43301266, 0, 0, 0)
@@ -63,3 +65,5 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.7434311, 1.3228927, 1.44800
 transform = Transform3D(0.25, 0, 0, 0, 0.25, 0, 0, 0, 0.25, -0.4765377, 0.8705983, 5.9624)
 
 [node name="UI" parent="." unique_id=933499048 instance=ExtResource("4_aqv4r")]
+
+[connection signal="body_entered" from="Hole" to="." method="_on_hole_body_entered"]


### PR DESCRIPTION
## Summary
- Attach `hole.gd` script to `hole.tscn` root node
- Implement state machine (`AIM`, `SET_POWER`, `SHOOT`, `WIN`) driving arrow aiming animation, power bar charge, shot counter, and win message
- Connect `body_entered` signal from the hole Area3D to `_on_hole_body_entered`
- `$Ball.shoot(...)` call left as TODO pending the upcoming Ball script issue

Closes #199