### PR TITLE
Add ball script for hole state machine

### DIFF
--- a/3d-minigolf/ball.gd
+++ b/3d-minigolf/ball.gd
@@ -1,0 +1,23 @@
+extends RigidBody3D
+
+signal stopped(angle: float)
+
+var was_moving = false
+var last_direction = Vector3.FORWARD
+
+func shoot(angle, power) -> void:
+	var force = Vector3.FORWARD.rotated(Vector3.UP, angle)
+	apply_central_impulse(force * power)
+
+func _integrate_forces(state: PhysicsDirectBodyState3D) -> void:
+	if state.linear_velocity.length() < 0.1:
+		state.linear_velocity = Vector3.ZERO
+		if was_moving:
+			var angle = Vector3.FORWARD.signed_angle_to(last_direction, Vector3.UP)
+			stopped.emit(angle)
+		was_moving = false
+	else:
+		last_direction = Vector3(state.linear_velocity.x, 0, state.linear_velocity.z)
+		was_moving = true
+	if position.y < -20:
+		get_tree().reload_current_scene()

--- a/3d-minigolf/ball.gd.uid
+++ b/3d-minigolf/ball.gd.uid
@@ -1,0 +1,1 @@
+uid://b6yufwupntrsi

--- a/3d-minigolf/ball.tscn
+++ b/3d-minigolf/ball.tscn
@@ -1,5 +1,10 @@
 [gd_scene format=3 uid="uid://bhkrakk3ieqi6"]
 
+[ext_resource type="Script" uid="uid://b6yufwupntrsi" path="res://ball.gd" id="1_x8fbi"]
+
+[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_cki6r"]
+bounce = 0.25
+
 [sub_resource type="SphereMesh" id="SphereMesh_mih3r"]
 radius = 0.05
 height = 0.1
@@ -7,14 +12,12 @@ height = 0.1
 [sub_resource type="SphereShape3D" id="SphereShape3D_mih3r"]
 radius = 0.05
 
-[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_cki6r"]
-bounce = 0.25
-
 [node name="Ball" type="RigidBody3D" unique_id=1294271037]
 physics_material_override = SubResource("PhysicsMaterial_cki6r")
 continuous_cd = true
 linear_damp = 0.5
 angular_damp = 1.0
+script = ExtResource("1_x8fbi")
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="." unique_id=762107907]
 mesh = SubResource("SphereMesh_mih3r")

--- a/3d-minigolf/hole.gd
+++ b/3d-minigolf/hole.gd
@@ -6,6 +6,7 @@ enum { AIM, SET_POWER, SHOOT, WIN }
 @export var angle_speed = 1.1
 
 var angle_change = 1
+var arrow_base_angle = 0.0
 var power = 0
 var power_change = 1
 var shots = 0
@@ -23,13 +24,13 @@ func change_state(new_state: int) -> void:
 	match state:
 		AIM:
 			$Arrow.position = $Ball.position
+			$Arrow.rotation.y = arrow_base_angle
 			$Arrow.show()
 		SET_POWER:
 			power = 0
 		SHOOT:
 			$Arrow.hide()
-			# To do
-			# $Ball.shoot($Arrow.rotation.y, power / 15)
+			$Ball.shoot($Arrow.rotation.y, power / 15)
 			shots += 1
 			$UI.update_shots(shots)
 		WIN:
@@ -57,9 +58,9 @@ func _process(delta: float) -> void:
 
 func animate_arrow(delta: float) -> void:
 	$Arrow.rotation.y += angle_speed * angle_change * delta
-	if $Arrow.rotation.y > PI / 2:
+	if $Arrow.rotation.y > arrow_base_angle + PI / 2:
 		angle_change = -1
-	if $Arrow.rotation.y < -PI / 2:
+	if $Arrow.rotation.y < arrow_base_angle - PI / 2:
 		angle_change = 1
 		
 func animate_power(delta: float) -> void:
@@ -75,3 +76,9 @@ func _on_hole_body_entered(body: Node3D) -> void:
 	if body.name == "Ball":
 		print("win!")
 		change_state(WIN)
+
+
+func _on_ball_stopped(angle: float) -> void:
+	if state == SHOOT:
+		arrow_base_angle = angle
+		change_state(AIM)

--- a/3d-minigolf/hole.tscn
+++ b/3d-minigolf/hole.tscn
@@ -44,7 +44,7 @@ data = {
 }
 
 [node name="Camera3D" type="Camera3D" parent="." unique_id=629442586]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.902955, 2.26505, 10.492782)
+transform = Transform3D(1, 0, 0, 0, 0.3164015, 0.9486254, 0, -0.9486254, 0.3164015, 1.902955, 5.5299954, 6.4667597)
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="." unique_id=1521819101]
 environment = SubResource("Environment_ln22a")
@@ -67,3 +67,4 @@ transform = Transform3D(0.25, 0, 0, 0, 0.25, 0, 0, 0, 0.25, -0.4765377, 0.870598
 [node name="UI" parent="." unique_id=933499048 instance=ExtResource("4_aqv4r")]
 
 [connection signal="body_entered" from="Hole" to="." method="_on_hole_body_entered"]
+[connection signal="stopped" from="Ball" to="." method="_on_ball_stopped"]


### PR DESCRIPTION
3D Mini Golf 튜토리얼 - Scripting the game 챕터 중 Ball 스크립트 작성 단계.

- `Ball.shoot()` 를 상태 머신에 연결하여 실제로 공이 발사되도록 구현
- 공이 멈출 때의 이동 방향을 계산해 `stopped(angle)` 시그널로 전달
- 조준 화살표가 마지막 이동 방향을 기준으로 좌우 90도씩 재조준되도록 수정 (코너에서 90도 이상 누적 회전 가능)

Closes #201