### PR TITLE
Add camera improvements

### DIFF
--- a/3d-minigolf/camera_gimbal.gd
+++ b/3d-minigolf/camera_gimbal.gd
@@ -1,0 +1,22 @@
+extends Node3D
+
+@export var cam_speed = PI / 2
+@export var zoom_speed = 0.1
+
+var zoom = 0.2
+
+func _input(event) -> void:
+	if event.is_action_pressed("cam_zoom_in"):
+		zoom -= zoom_speed
+	if event.is_action_pressed("cam_zoom_out"):
+		zoom += zoom_speed
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	zoom = clamp(zoom, 0.1, 2.0)
+	scale = Vector3.ONE * zoom
+	var y = Input.get_axis("cam_left", "cam_right")
+	rotate_y(y * cam_speed * delta)
+	var x = Input.get_axis("cam_up", "cam_down")
+	$GimbalInner.rotate_x(x * cam_speed * delta)
+	$GimbalInner.rotation.x = clamp($GimbalInner.rotation.x, -PI / 2, -0.2)

--- a/3d-minigolf/camera_gimbal.gd.uid
+++ b/3d-minigolf/camera_gimbal.gd.uid
@@ -1,0 +1,1 @@
+uid://b4xeyikjvvnqt

--- a/3d-minigolf/camera_gimbal.tscn
+++ b/3d-minigolf/camera_gimbal.tscn
@@ -1,0 +1,11 @@
+[gd_scene format=3 uid="uid://c7iksisfr00ov"]
+
+[ext_resource type="Script" uid="uid://b4xeyikjvvnqt" path="res://camera_gimbal.gd" id="1_031mj"]
+
+[node name="CameraGimbal" type="Node3D" unique_id=902299175]
+script = ExtResource("1_031mj")
+
+[node name="GimbalInner" type="Node3D" parent="." unique_id=816703196]
+
+[node name="Camera3D" type="Camera3D" parent="GimbalInner" unique_id=1498582660]
+transform = Transform3D(1, 0, 0, 0, 0.9396926, 0.34202012, 0, -0.34202012, 0.9396926, 0, 2, 10)

--- a/3d-minigolf/hole.gd
+++ b/3d-minigolf/hole.gd
@@ -55,6 +55,8 @@ func _process(delta: float) -> void:
 			animate_power(delta)
 		SHOOT:
 			pass
+	if state != WIN:
+		$CameraGimbal.position = $Ball.position
 
 func animate_arrow(delta: float) -> void:
 	$Arrow.rotation.y += angle_speed * angle_change * delta

--- a/3d-minigolf/hole.tscn
+++ b/3d-minigolf/hole.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="PackedScene" uid="uid://bhkrakk3ieqi6" path="res://ball.tscn" id="2_1s0jb"]
 [ext_resource type="PackedScene" uid="uid://c8cbc2rtt0pis" path="res://arrow.tscn" id="3_cki6r"]
 [ext_resource type="PackedScene" uid="uid://6voinnuhm3gg" path="res://ui.tscn" id="4_aqv4r"]
+[ext_resource type="PackedScene" uid="uid://c7iksisfr00ov" path="res://camera_gimbal.tscn" id="6_q7xbi"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_j4rvs"]
 rough = true
@@ -43,9 +44,6 @@ data = {
 "cells": PackedInt32Array(65535, 6, 22, 65535, 5, 655384, 65535, 4, 655384, 65535, 3, 655384, 65535, 2, 655384, 65535, 1, 0, 0, 1, 1441796, 1, 1, 1441817, 2, 1, 1441822, 3, 1, 1441794, 3, 2, 655392, 3, 3, 655392, 3, 4, 655393, 3, 5, 655388, 3, 6, 655387, 3, 7, 1)
 }
 
-[node name="Camera3D" type="Camera3D" parent="." unique_id=629442586]
-transform = Transform3D(1, 0, 0, 0, 0.3164015, 0.9486254, 0, -0.9486254, 0.3164015, 1.902955, 5.5299954, 6.4667597)
-
 [node name="WorldEnvironment" type="WorldEnvironment" parent="." unique_id=1521819101]
 environment = SubResource("Environment_ln22a")
 
@@ -65,6 +63,8 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.7434311, 1.3228927, 1.44800
 transform = Transform3D(0.25, 0, 0, 0, 0.25, 0, 0, 0, 0.25, -0.4765377, 0.8705983, 5.9624)
 
 [node name="UI" parent="." unique_id=933499048 instance=ExtResource("4_aqv4r")]
+
+[node name="CameraGimbal" parent="." unique_id=902299175 instance=ExtResource("6_q7xbi")]
 
 [connection signal="body_entered" from="Hole" to="." method="_on_hole_body_entered"]
 [connection signal="stopped" from="Ball" to="." method="_on_ball_stopped"]

--- a/3d-minigolf/project.godot
+++ b/3d-minigolf/project.godot
@@ -27,6 +27,36 @@ click={
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
 ]
 }
+cam_left={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"location":0,"echo":false,"script":null)
+]
+}
+cam_right={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
+]
+}
+cam_up={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"location":0,"echo":false,"script":null)
+]
+}
+cam_down={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
+]
+}
+cam_zoom_in={
+"deadzone": 0.2,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":4,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
+cam_zoom_out={
+"deadzone": 0.2,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":5,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
 
 [physics]
 


### PR DESCRIPTION
3D Mini Golf 튜토리얼 - Camera improvements 단계.

- 고정 Camera3D를 CameraGimbal(회전/줌) 구조로 교체
- WASD로 카메라 좌우/상하 회전, 마우스 휠로 줌 인/아웃 (scale 기반)
- GimbalInner 회전 clamp로 카메라가 뒤집히지 않도록 제한
- 매 프레임 CameraGimbal 위치를 Ball 위치로 갱신하여 공을 따라가도록 구현 (WIN 상태 제외)

Closes #203