### PR TITLE
Add second hole course loaded after clearing the first hole

### DIFF
--- a/3d-minigolf/hole.gd
+++ b/3d-minigolf/hole.gd
@@ -4,6 +4,7 @@ enum { AIM, SET_POWER, SHOOT, WIN }
 
 @export var power_speed = 100
 @export var angle_speed = 1.1
+@export var next_hole : PackedScene
 
 var angle_change = 1
 var arrow_base_angle = 0.0
@@ -36,7 +37,11 @@ func change_state(new_state: int) -> void:
 		WIN:
 			$Ball.hide()
 			$Arrow.hide()
-			$UI.show_message("Win!")
+			await get_tree().create_timer(1).timeout
+			if next_hole:
+				get_tree().change_scene_to_packed(next_hole)
+			else:
+				$UI.show_message("Win!")
 
 func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("click"):

--- a/3d-minigolf/hole.tscn
+++ b/3d-minigolf/hole.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://c8cbc2rtt0pis" path="res://arrow.tscn" id="3_cki6r"]
 [ext_resource type="PackedScene" uid="uid://6voinnuhm3gg" path="res://ui.tscn" id="4_aqv4r"]
 [ext_resource type="PackedScene" uid="uid://c7iksisfr00ov" path="res://camera_gimbal.tscn" id="6_q7xbi"]
+[ext_resource type="PackedScene" path="res://hole_2.tscn" id="7_hole2"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_j4rvs"]
 rough = true
@@ -30,6 +31,7 @@ radius = 0.08
 
 [node name="Hole" type="Node3D" unique_id=10753398]
 script = ExtResource("1_cr06n")
+next_hole = ExtResource("7_hole2")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="." unique_id=1395984302]
 transform = Transform3D(-0.8660254, -0.43301278, 0.25, 0, 0.49999997, 0.86602545, -0.50000006, 0.75, -0.43301266, 0, 0, 0)

--- a/3d-minigolf/hole_2.tscn
+++ b/3d-minigolf/hole_2.tscn
@@ -1,0 +1,70 @@
+[gd_scene load_steps=9 format=3]
+
+[ext_resource type="Script" path="res://hole.gd" id="1_h2scr"]
+[ext_resource type="MeshLibrary" path="res://golf_tiles.meshlib" id="2_h2lib"]
+[ext_resource type="PackedScene" path="res://ball.tscn" id="3_h2ball"]
+[ext_resource type="PackedScene" path="res://arrow.tscn" id="4_h2arrow"]
+[ext_resource type="PackedScene" path="res://ui.tscn" id="5_h2ui"]
+[ext_resource type="PackedScene" path="res://camera_gimbal.tscn" id="6_h2cam"]
+
+[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_h2a"]
+rough = true
+bounce = 0.5
+
+[sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_h2a"]
+
+[sub_resource type="Sky" id="Sky_h2a"]
+sky_material = SubResource("ProceduralSkyMaterial_h2a")
+
+[sub_resource type="Environment" id="Environment_h2a"]
+background_mode = 2
+background_energy_multiplier = 3.84
+sky = SubResource("Sky_h2a")
+ambient_light_source = 3
+ambient_light_sky_contribution = 0.11
+reflected_light_source = 2
+
+[sub_resource type="CylinderShape3D" id="CylinderShape3D_h2a"]
+height = 0.25
+radius = 0.08
+
+[node name="Hole" type="Node3D"]
+script = ExtResource("1_h2scr")
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+transform = Transform3D(-0.8660254, -0.43301278, 0.25, 0, 0.49999997, 0.86602545, -0.50000006, 0.75, -0.43301266, 0, 0, 0)
+shadow_enabled = true
+directional_shadow_max_distance = 40.0
+
+[node name="GridMap" type="GridMap" parent="."]
+mesh_library = ExtResource("2_h2lib")
+physics_material = SubResource("PhysicsMaterial_h2a")
+cell_size = Vector3(1, 1, 1)
+data = {
+"cells": PackedInt32Array(65535, 9, 22, 65535, 8, 655384, 65535, 7, 655384, 65535, 6, 655388, 65535, 5, 655384, 65535, 4, 0, 0, 4, 1441796, 1, 4, 1441817, 2, 4, 1441792, 2, 5, 655384, 2, 6, 655392, 2, 7, 655384, 2, 8, 655388, 2, 9, 1048576, 3, 9, 1441822, 4, 9, 1441817, 5, 9, 655360, 5, 8, 655384, 5, 7, 655393, 5, 6, 655388, 5, 5, 655384, 5, 4, 655392, 5, 3, 655387, 5, 2, 1)
+}
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+environment = SubResource("Environment_h2a")
+
+[node name="Hole" type="Area3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.4984236, 0.41371524, 2.489729)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Hole"]
+shape = SubResource("CylinderShape3D_h2a")
+
+[node name="Tee" type="Marker3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.488662, 0.85620403, 8.9747605)
+
+[node name="Ball" parent="." instance=ExtResource("3_h2ball")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.488662, 0.85620403, 8.9747605)
+
+[node name="Arrow" parent="." instance=ExtResource("4_h2arrow")]
+transform = Transform3D(0.25, 0, 0, 0, 0.25, 0, 0, 0, 0.25, -0.476562, 0.870604, 8.962361)
+
+[node name="UI" parent="." instance=ExtResource("5_h2ui")]
+
+[node name="CameraGimbal" parent="." instance=ExtResource("6_h2cam")]
+
+[connection signal="body_entered" from="Hole" to="." method="_on_hole_body_entered"]
+[connection signal="stopped" from="Ball" to="." method="_on_ball_stopped"]


### PR DESCRIPTION
Closes #205

## 변경 사항
- `hole.gd`: `next_hole` export 변수 추가, WIN 상태에서 1초 후 다음 홀 씬으로 전환 (없으면 기존처럼 "Win!" 메시지 표시)
- `hole_2.tscn`: M자(지그재그) 형태의 두 번째 코스 신규 추가 — 24타일, 방향 전환 4회, 홀 진입 전 언덕(`straight_hill`) 배치
- `hole.tscn`: `next_hole`에 `hole_2.tscn` 할당

## 데모
(hole.tscn 클리어 → hole_2.tscn 전환 영상 첨부 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)