### PR TITLE
Add dimpled ball material with normal map

### DIFF
--- a/3d-minigolf/assets/ball_normal_map.png.import
+++ b/3d-minigolf/assets/ball_normal_map.png.import
@@ -3,30 +3,31 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://dk4b8i00bvj5e"
-path="res://.godot/imported/ball_normal_map.png-f16dcc0380cc66c64ac11305f0199948.ctex"
+path.s3tc="res://.godot/imported/ball_normal_map.png-f16dcc0380cc66c64ac11305f0199948.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ball_normal_map.png"
-dest_files=["res://.godot/imported/ball_normal_map.png-f16dcc0380cc66c64ac11305f0199948.ctex"]
+dest_files=["res://.godot/imported/ball_normal_map.png-f16dcc0380cc66c64ac11305f0199948.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/uastc_level=0
 compress/rdo_quality_loss=0.0
 compress/hdr_compression=1
-compress/normal_map=0
+compress/normal_map=1
 compress/channel_pack=0
-mipmaps/generate=false
+mipmaps/generate=true
 mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
+roughness/mode=1
+roughness/src_normal="res://assets/ball_normal_map.png"
 process/channel_remap/red=0
 process/channel_remap/green=1
 process/channel_remap/blue=2
@@ -37,4 +38,4 @@ process/normal_map_invert_y=false
 process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
-detect_3d/compress_to=1
+detect_3d/compress_to=0

--- a/3d-minigolf/ball.tscn
+++ b/3d-minigolf/ball.tscn
@@ -1,11 +1,18 @@
 [gd_scene format=3 uid="uid://bhkrakk3ieqi6"]
 
 [ext_resource type="Script" uid="uid://b6yufwupntrsi" path="res://ball.gd" id="1_x8fbi"]
+[ext_resource type="Texture2D" uid="uid://dk4b8i00bvj5e" path="res://assets/ball_normal_map.png" id="2_41u45"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_cki6r"]
 bounce = 0.25
 
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_q7xbi"]
+normal_enabled = true
+normal_scale = -0.69
+normal_texture = ExtResource("2_41u45")
+
 [sub_resource type="SphereMesh" id="SphereMesh_mih3r"]
+material = SubResource("StandardMaterial3D_q7xbi")
 radius = 0.05
 height = 0.1
 


### PR DESCRIPTION
Closes #207

## 변경 사항
- `ball.tscn`: `StandardMaterial3D`를 새로 추가하고 골프공 딤플 노멀 맵(`ball_normal_map.png`) 적용, `SphereMesh`의 material로 할당
- `assets/ball_normal_map.png.import`: 텍스처를 노멀 맵 용도로 재임포트 (VRAM 압축, 밉맵 생성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)