### PR TITLE
Add airplane scene

### DIFF
--- a/infinite-flyer/plane.tscn
+++ b/infinite-flyer/plane.tscn
@@ -1,0 +1,8 @@
+[gd_scene format=3 uid="uid://ee3ykmyydtfc"]
+
+[ext_resource type="PackedScene" uid="uid://b0u8i0vqnnt3o" path="res://assets/cartoon_plane.glb" id="1_s46f0"]
+
+[node name="Plane" type="CharacterBody3D" unique_id=2078837377]
+
+[node name="cartoon_plane" parent="." unique_id=380085897 instance=ExtResource("1_s46f0")]
+transform = Transform3D(-1, 0, -8.742278e-08, 0, 1, 0, 8.742278e-08, 0, -1, 0, 0, 0)


### PR DESCRIPTION
## Summary
- Add `plane.tscn`: `CharacterBody3D` root ("Plane") with `cartoon_plane.glb` instanced as child
- Model rotated 180° on Y so the plane faces Godot's forward direction (-Z)

Part of #210, part of #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)