### PR TITLE
Add collision shapes

### DIFF
--- a/infinite-flyer/plane.tscn
+++ b/infinite-flyer/plane.tscn
@@ -2,7 +2,22 @@
 
 [ext_resource type="PackedScene" uid="uid://b0u8i0vqnnt3o" path="res://assets/cartoon_plane.glb" id="1_s46f0"]
 
+[sub_resource type="CylinderShape3D" id="CylinderShape3D_16mm7"]
+height = 3.5
+radius = 1.0
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_16mm7"]
+size = Vector3(7, 1, 2)
+
 [node name="Plane" type="CharacterBody3D" unique_id=2078837377]
 
 [node name="cartoon_plane" parent="." unique_id=380085897 instance=ExtResource("1_s46f0")]
 transform = Transform3D(-1, 0, -8.742278e-08, 0, 1, 0, 8.742278e-08, 0, -1, 0, 0, 0)
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="." unique_id=1537215244]
+transform = Transform3D(1, 0, 0, 0, -4.371139e-08, 1, 0, -1, -4.371139e-08, 0, -1.0927847e-08, -0.25)
+shape = SubResource("CylinderShape3D_16mm7")
+
+[node name="CollisionShape3D2" type="CollisionShape3D" parent="." unique_id=1988737318]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.5)
+shape = SubResource("BoxShape3D_16mm7")


### PR DESCRIPTION
## Summary
- Add two collision shapes to `plane.tscn`:
  - `CylinderShape3D` (height 3.5, radius 1.0) rotated -90° on X to cover the fuselage
  - `BoxShape3D` (7 × 1 × 2) to cover the wings

Part of #215, resolves #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)