### PR TITLE
Add plane script

### DIFF
--- a/infinite-flyer/plane.gd
+++ b/infinite-flyer/plane.gd
@@ -1,0 +1,26 @@
+extends CharacterBody3D
+
+@export var pitch_speed = 1.1
+@export var roll_speed = 2.5
+@export var level_speed = 4.0
+@export var forward_speed = 25
+
+var roll_input = 0
+var pitch_input = 0
+var max_altitude = 20
+
+func get_input(delta) -> void:
+	pitch_input = Input.get_axis("pitch_down", "pitch_up")
+	roll_input = Input.get_axis("roll_left", "roll_right")
+	if position.y >= max_altitude and pitch_input > 0:
+		position.y = max_altitude
+		pitch_input = 0
+	
+func _physics_process(delta: float) -> void:
+	get_input(delta)
+	rotation.x = lerpf(rotation.x, pitch_input, pitch_speed * delta)
+	rotation.x = clamp(rotation.x, deg_to_rad(-45), deg_to_rad(45))
+	$cartoon_plane.rotation.z = lerpf($cartoon_plane.rotation.z, roll_input, roll_speed * delta)
+	velocity = -transform.basis.z * forward_speed
+	velocity += transform.basis.x * $cartoon_plane.rotation.z / deg_to_rad(45) * forward_speed / 2.0
+	move_and_slide()

--- a/infinite-flyer/plane.gd.uid
+++ b/infinite-flyer/plane.gd.uid
@@ -1,0 +1,1 @@
+uid://c7swuxr0owtv6

--- a/infinite-flyer/plane.tscn
+++ b/infinite-flyer/plane.tscn
@@ -1,5 +1,6 @@
 [gd_scene format=3 uid="uid://ee3ykmyydtfc"]
 
+[ext_resource type="Script" uid="uid://c7swuxr0owtv6" path="res://plane.gd" id="1_dpar4"]
 [ext_resource type="PackedScene" uid="uid://b0u8i0vqnnt3o" path="res://assets/cartoon_plane.glb" id="1_s46f0"]
 
 [sub_resource type="CylinderShape3D" id="CylinderShape3D_16mm7"]
@@ -10,6 +11,7 @@ radius = 1.0
 size = Vector3(7, 1, 2)
 
 [node name="Plane" type="CharacterBody3D" unique_id=2078837377]
+script = ExtResource("1_dpar4")
 
 [node name="cartoon_plane" parent="." unique_id=380085897 instance=ExtResource("1_s46f0")]
 transform = Transform3D(-1, 0, -8.742278e-08, 0, 1, 0, 8.742278e-08, 0, -1, 0, 0, 0)

--- a/infinite-flyer/project.godot
+++ b/infinite-flyer/project.godot
@@ -11,6 +11,7 @@ config_version=5
 [application]
 
 config/name="InfiniteFlyer"
+run/main_scene="uid://bw8lt7d5ttke8"
 config/features=PackedStringArray("4.7", "Forward Plus")
 config/icon="res://icon.svg"
 

--- a/infinite-flyer/test.tscn
+++ b/infinite-flyer/test.tscn
@@ -1,0 +1,10 @@
+[gd_scene format=3 uid="uid://bw8lt7d5ttke8"]
+
+[ext_resource type="PackedScene" uid="uid://ee3ykmyydtfc" path="res://plane.tscn" id="1_37kl0"]
+
+[node name="Test" type="Node3D" unique_id=778927854]
+
+[node name="Plane" parent="." unique_id=2078837377 instance=ExtResource("1_37kl0")]
+
+[node name="Camera3D" type="Camera3D" parent="." unique_id=1697651748]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 6)


### PR DESCRIPTION
## Summary
- Add `plane.gd`: pitch/roll input, banking-based lateral movement, forward flight at constant speed, altitude limit
- Attach the script to `plane.tscn`
- Add `test.tscn` (Plane + Camera3D) for testing the plane in isolation
- Set `run/main_scene` to `test.tscn`

Part of #215, resolves #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)